### PR TITLE
feat: Cat 173 fe 게임 점수 공유/Cat 170 fe 게임 순위 조회/Cat fe 게임 점수 조회

### DIFF
--- a/src/api/game.js
+++ b/src/api/game.js
@@ -1,0 +1,13 @@
+import api from '@/api/axios.js';
+
+/* 1. 게임 베스트 기록 저장 */
+export function saveGameScore(score) {
+  return api.post('/games/scores', { score });
+}
+
+/* 2. 게임 랭킹 조회 */
+export function getGameRanking(memberId, limit = 10) {
+  return api.get('/games/scores/ranking', {
+    params: { memberId, limit },
+  });
+}

--- a/src/components/layout/SidebarMainLayout.vue
+++ b/src/components/layout/SidebarMainLayout.vue
@@ -47,6 +47,6 @@ function handleOpenUploadModal() {
 }
 
 .main-content {
-  @apply flex-1 p-10 overflow-y-auto bg-white;
+  @apply flex-1 overflow-y-auto bg-white;
 }
 </style>

--- a/src/features/game/components/Card.vue
+++ b/src/features/game/components/Card.vue
@@ -1,0 +1,61 @@
+<script setup>
+const props = defineProps({
+  card: {
+    type: Object,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['click']);
+
+function handleClick() {
+  emit('click');
+}
+</script>
+
+<template>
+  <div class="card-container" @click="handleClick">
+    <div :class="['card-inner', card.isFlipped || card.isMatched ? 'flipped' : '']">
+      <div class="card-face card-front">
+        <img :src="card.img" alt="고양이 앞면" class="card-image" />
+      </div>
+      <div class="card-face card-back">
+        <img src="@/assets/logo.png" alt="카드 뒷면" class="card-image" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.card-container {
+  @apply w-[100px] h-[140px];
+  perspective: 1000px;
+}
+
+.card-inner {
+  @apply relative w-full h-full transition-transform duration-500 rounded-md bg-white;
+  transform-style: preserve-3d;
+}
+
+.card-inner.flipped {
+  transform: rotateY(180deg);
+}
+
+.card-face {
+  @apply absolute w-full h-full overflow-hidden rounded-lg p-2;
+  backface-visibility: hidden;
+}
+
+.card-front {
+  transform: rotateY(180deg);
+  z-index: 2;
+}
+
+.card-back {
+  z-index: 1;
+}
+
+.card-image {
+  @apply w-full h-full object-contain;
+}
+</style>

--- a/src/features/game/components/ImageSelectModal.vue
+++ b/src/features/game/components/ImageSelectModal.vue
@@ -1,0 +1,135 @@
+<script setup>
+import { ref, computed } from 'vue';
+
+const emit = defineEmits(['close', 'imagesSelected']);
+const imageFiles = ref([]); // { file: File, url: string }[]
+
+function handleFileChange(event) {
+  const files = [...event.target.files];
+  const validFiles = files.slice(0, 8 - imageFiles.value.length);
+
+  validFiles.forEach((file) => {
+    const url = URL.createObjectURL(file);
+    imageFiles.value.push({ file, url });
+  });
+
+  event.target.value = '';
+}
+
+function removeImage(index) {
+  const removed = imageFiles.value.splice(index, 1);
+  if (removed[0]?.url) URL.revokeObjectURL(removed[0].url);
+}
+
+function confirmSelection() {
+  const files = imageFiles.value.map((item) => item.file);
+  emit('imagesSelected', files);
+  emit('close');
+}
+
+// 항상 8칸으로 맞춘 배열 (빈 칸은 null)
+const paddedImages = computed(() => {
+  const padded = [...imageFiles.value];
+  while (padded.length < 8) padded.push(null);
+  return padded;
+});
+</script>
+
+<template>
+  <div class="modal-backdrop">
+    <section class="modal-container" role="dialog" aria-modal="true">
+      <h1 class="modal-title">카드 이미지 선택 (최대 8장)</h1>
+      <p class="modal-subtitle">원하는 고양이 이미지를 최대 8장까지 선택해주세요.</p>
+
+      <div class="file-upload">
+        <label for="imageUpload" class="file-label">이미지 선택하기</label>
+        <input type="file" id="imageUpload" accept="image/*" multiple @change="handleFileChange" />
+      </div>
+
+      <div class="preview-grid">
+        <div v-for="(item, index) in paddedImages" :key="index" class="preview-item relative">
+          <template v-if="item">
+            <img :src="item.url" :alt="`preview-${index + 1}`" />
+            <button class="remove-button" @click="removeImage(index)" aria-label="삭제">×</button>
+          </template>
+          <template v-else>
+            <div class="placeholder" />
+          </template>
+        </div>
+      </div>
+
+      <div class="note">※ 8장 미만 선택 시, 기본 이미지가 자동으로 포함됩니다.</div>
+
+      <div class="confirm-buttons">
+        <button class="confirm" @click="confirmSelection">확인</button>
+        <button class="cancel" @click="$emit('close')">닫기</button>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.modal-backdrop {
+  @apply fixed inset-0 bg-black bg-opacity-20 backdrop-blur-sm flex items-center justify-center z-50;
+}
+
+.modal-container {
+  @apply bg-white border border-pink-200 p-10 rounded-xl shadow-md max-w-3xl w-[90%] text-center;
+}
+
+.modal-title {
+  @apply text-2xl font-bold text-pink-500 mb-3;
+}
+
+.modal-subtitle {
+  @apply text-sm text-gray-600 mb-6;
+}
+
+.file-upload {
+  @apply flex justify-center mb-5;
+}
+
+.file-label {
+  @apply bg-pink-500 text-white px-5 py-2 rounded-lg text-sm font-semibold cursor-pointer hover:bg-pink-600;
+}
+
+input[type='file'] {
+  display: none;
+}
+
+.preview-grid {
+  @apply grid grid-cols-4 gap-3 mt-5;
+}
+
+.preview-item {
+  @apply relative w-full pt-[100%] bg-white rounded-lg overflow-hidden border border-gray-200 shadow-sm;
+}
+
+.preview-item img {
+  @apply absolute top-0 left-0 w-full h-full object-cover;
+}
+
+.placeholder {
+  @apply absolute top-0 left-0 w-full h-full bg-gray-100;
+}
+
+.remove-button {
+  @apply absolute top-1 right-1 bg-black bg-opacity-50 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs hover:bg-opacity-80;
+}
+
+.note {
+  @apply mt-5 text-sm text-yellow-500;
+}
+
+.confirm-buttons {
+  @apply mt-6 flex justify-center gap-4;
+}
+
+.confirm {
+  @apply bg-pink-500 text-white px-5 py-2 rounded-md font-semibold hover:bg-pink-600;
+}
+
+.cancel {
+  @apply bg-gray-200 text-gray-700 px-5 py-2 rounded-md font-semibold hover:bg-gray-300;
+}
+</style>

--- a/src/features/game/components/vues.vue
+++ b/src/features/game/components/vues.vue
@@ -1,11 +1,5 @@
-<script setup>
+<script setup></script>
 
-</script>
+<다template>game입니다</다template>
 
-<template>
-
-</template>
-
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/features/game/router.js
+++ b/src/features/game/router.js
@@ -1,0 +1,26 @@
+export default [
+  {
+    path: '/game',
+    children: [
+      { path: '', redirect: '/game/start' }, // 기본 리다이렉트,
+      {
+        path: 'start',
+        name: 'GameStart',
+        component: () => import('@/features/game/views/GameStart.vue'),
+        meta: { requiresAuth: true, title: '게임 시작' },
+      },
+      {
+        path: 'play',
+        name: 'GamePlay',
+        component: () => import('@/features/game/views/GamePlay.vue'),
+        meta: { requiresAuth: true, title: '게임 중' },
+      },
+      {
+        path: 'ranking',
+        name: 'GameRanking',
+        component: () => import('@/features/game/views/GameRanking.vue'),
+        meta: { requiresAuth: false, title: '랭킹 조회' },
+      },
+    ],
+  },
+];

--- a/src/features/game/views/GamePlay.vue
+++ b/src/features/game/views/GamePlay.vue
@@ -1,0 +1,187 @@
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
+import { useGameStore } from '@/stores/useGameStore.js';
+import { useRouter } from 'vue-router';
+import Card from '@/features/game/components/Card.vue';
+import { saveGameScore } from '@/api/game.js';
+import { showErrorToast } from '@/utills/toast.js';
+
+const router = useRouter();
+const gameStore = useGameStore();
+
+const cards = ref([]);
+const flipped = ref([]);
+const startTime = ref(0);
+const now = ref(Date.now());
+const blobUrls = ref([]); // blob URL 저장소
+const maxTimeMs = 60 * 1000; // 60초 제한
+let animationFrameId;
+let gameEnded = false;
+
+const elapsedMs = computed(() => Math.min(now.value - startTime.value, maxTimeMs));
+const progressPercent = computed(() => (elapsedMs.value / maxTimeMs) * 100);
+
+function formatTime(ms) {
+  const totalSec = Math.floor(ms / 1000);
+  const min = String(Math.floor(totalSec / 60)).padStart(2, '0');
+  const sec = String(totalSec % 60).padStart(2, '0');
+  const msStr = String(Math.floor((ms % 1000) / 10)).padStart(2, '2');
+  return `${min}:${sec}.${msStr}`;
+}
+
+function tick() {
+  now.value = Date.now();
+  if (elapsedMs.value < maxTimeMs && !gameEnded) {
+    animationFrameId = requestAnimationFrame(tick);
+  } else if (!gameEnded) {
+    gameEnded = true;
+    cancelAnimationFrame(animationFrameId);
+
+    gameStore.setResult({ time: null, status: 'fail' });
+    router.push('/game/ranking');
+  }
+}
+
+function startTimer() {
+  startTime.value = Date.now();
+  now.value = Date.now();
+  tick();
+}
+
+function shuffle(array) {
+  return [...array].sort(() => Math.random() - 0.5);
+}
+
+function generateCards() {
+  const files = gameStore.selectedFiles;
+
+  // 기존 URL 해제
+  blobUrls.value.forEach((url) => URL.revokeObjectURL(url));
+  blobUrls.value = [];
+
+  const selected = files.map((file) => {
+    const url = URL.createObjectURL(file);
+    blobUrls.value.push(url);
+    return url;
+  });
+
+  const needed = 8 - selected.length;
+
+  const defaultImages = import.meta.glob('@/assets/default_images/*.png', {
+    eager: true,
+    import: 'default',
+  });
+
+  const defaultList = Object.values(defaultImages).slice(0, needed);
+  const allImages = [...selected, ...defaultList];
+
+  const paired = allImages.flatMap((img, i) => [
+    { id: i * 2, value: i, img, isFlipped: false, isMatched: false },
+    { id: i * 2 + 1, value: i, img, isFlipped: false, isMatched: false },
+  ]);
+
+  cards.value = shuffle(paired);
+}
+
+async function handleCardClick(card) {
+  if (card.isFlipped || card.isMatched || flipped.value.length === 2) return;
+
+  card.isFlipped = true;
+  flipped.value.push(card);
+
+  if (flipped.value.length === 2) {
+    const [a, b] = flipped.value;
+    if (a.value === b.value) {
+      a.isMatched = b.isMatched = true;
+      flipped.value = [];
+
+      if (cards.value.every((c) => c.isMatched)) {
+        gameEnded = true;
+        cancelAnimationFrame(animationFrameId);
+
+        const finishedTimeSec = elapsedMs.value;
+        gameStore.setResult({ time: finishedTimeSec, status: 'success' });
+
+        try {
+          await saveGameScore(finishedTimeSec);
+        } catch (err) {
+          console.error('게임 점수 저장 실패:', err?.response?.data || err.message);
+          showErrorToast('게임 점수 저장에 실패했다냥ㅠㅠㅠ 다시 시도해달라냥 ㅠㅠㅠ.');
+          return; // 점수 저장 실패 시 랭킹 페이지로 이동하지 않도록 방지
+        }
+
+        setTimeout(async () => {
+          await router.push('/game/ranking');
+        }, 600);
+      }
+    } else {
+      setTimeout(() => {
+        a.isFlipped = b.isFlipped = false;
+        flipped.value = [];
+      }, 800);
+    }
+  }
+}
+
+onMounted(() => {
+  generateCards();
+  startTimer();
+});
+
+onBeforeUnmount(() => {
+  cancelAnimationFrame(animationFrameId);
+  blobUrls.value.forEach((url) => URL.revokeObjectURL(url));
+});
+</script>
+
+<template>
+  <main class="game-play-wrapper">
+    <h1 class="game-title">Catch Me! 고양이 카드 게임</h1>
+
+    <section class="timer-wrapper">
+      <div class="timer-bar">
+        <div class="timer-fill" :style="{ width: `${progressPercent}%` }"></div>
+      </div>
+      <p class="timer-label">⏱️ {{ formatTime(elapsedMs) }}</p>
+    </section>
+
+    <section class="board">
+      <Card
+        v-for="card in cards"
+        :key="card.id"
+        :card="card"
+        @click="() => handleCardClick(card)"
+      />
+    </section>
+  </main>
+</template>
+
+<style scoped>
+.game-play-wrapper {
+  @apply min-h-screen py-10 px-5 bg-gray-50 flex flex-col justify-center items-center;
+}
+
+.game-title {
+  @apply text-[28px] text-gray-700 font-bold mb-8;
+}
+
+.timer-wrapper {
+  @apply w-[600px] mx-auto mb-6;
+}
+
+.timer-bar {
+  @apply h-[18px] bg-white border border-gray-200 rounded-[12px] shadow overflow-hidden relative;
+}
+
+.timer-fill {
+  @apply h-full bg-gradient-to-r from-green-200 via-yellow-200 to-yellow-400 transition-all duration-300 ease-in-out rounded-[12px];
+}
+
+.timer-label {
+  @apply mt-2 text-sm font-medium text-gray-600 tracking-wider;
+}
+
+.board {
+  @apply grid grid-cols-4 gap-[20px] w-[550px];
+}
+</style>

--- a/src/features/game/views/GameRanking.vue
+++ b/src/features/game/views/GameRanking.vue
@@ -1,0 +1,201 @@
+<script setup>
+import { ref, onMounted, nextTick, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import { getGameRanking } from '@/api/game.js';
+import { useGameStore } from '@/stores/useGameStore.js';
+
+const router = useRouter();
+const gameStore = useGameStore();
+const memberId = 1;
+const limit = 10;
+
+const isFail = ref(false);
+const myScore = ref(null);
+const topPercentage = ref(null);
+const rankers = ref([]);
+
+onMounted(async () => {
+  await nextTick();
+
+  // if (gameStore.gameStatus == null) {
+  //   router.push('/game/start');
+  //   return;
+  // }
+
+  isFail.value = gameStore.gameStatus === 'fail';
+
+  try {
+    const response = await getGameRanking(memberId, limit);
+    const data = response.data.data;
+
+    rankers.value = data.topRankers.sort((a, b) => a.score - b.score);
+
+    if (!isFail.value) {
+      myScore.value = gameStore.time;
+      topPercentage.value = data.topPercentage;
+    }
+  } catch (err) {
+    console.error('랭킹 조회 실패:', err);
+    alert('랭킹 조회에 실패했습니다.');
+  }
+});
+
+const shareUrl = window.location.href;
+const shareText = ref('');
+
+watch(myScore, (score) => {
+  if (score !== null) {
+    shareText.value = `내가 Catch Me! 게임에서 ${Math.floor(score / 1000)}초 기록! 너도 도전해봐!`;
+  }
+});
+
+function shareTwitter() {
+  const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText.value)}&url=${encodeURIComponent(shareUrl)}`;
+  window.open(url, '_blank');
+}
+
+function shareFacebook() {
+  const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`;
+  window.open(url, '_blank');
+}
+
+function copyLink() {
+  navigator.clipboard.writeText(shareUrl).then(() => {
+    alert('링크가 복사되었습니다!');
+  });
+}
+
+function getRankClass(rank, isMe) {
+  const base = ['rank-card'];
+  if (rank === 1) base.push('rank-1');
+  if (rank === 2) base.push('rank-2');
+  if (rank === 3) base.push('rank-3');
+  if (isMe) base.push('my-rank');
+  return base.join(' ');
+}
+</script>
+
+<template>
+  <main class="ranking-container">
+    <h1 class="ranking-title">Catch Me! 게임 랭킹</h1>
+
+    <section class="score-box">
+      <p class="my-score">
+        <strong>
+          {{ isFail ? '맞추기 실패ㅠㅠ' : '내 기록:' + Math.floor(myScore / 1000) + '초' }}
+        </strong>
+      </p>
+      <p class="percent-rank">
+        {{ isFail ? '아쉽다냥...' : '상위 ' + Math.round(topPercentage) + '%에 속합니다' }}
+      </p>
+      <div class="share-section">
+        <button @click="shareTwitter" class="sns-btn twitter">X</button>
+        <button @click="shareFacebook" class="sns-btn facebook">f</button>
+        <button @click="copyLink" class="sns-btn link">🔗</button>
+      </div>
+    </section>
+
+    <ul class="rank-list">
+      <li
+        v-for="ranker in rankers"
+        :key="ranker.rank"
+        :class="getRankClass(ranker.rank, !isFail && ranker.memberId == memberId)"
+      >
+        <div class="flex items-center gap-2">
+          <i v-if="ranker.rank === 1" class="fas fa-crown text-yellow-400 text-[18px]" />
+          <span class="rank-text">
+            {{ ranker.rank }}위
+            <span v-if="!isFail && ranker.memberId == memberId" class="ml-1 text-pink-400 font-bold"
+              >(나)</span
+            >
+          </span>
+        </div>
+        <span class="score-text">{{ Math.floor(ranker.score / 1000) }}초</span>
+      </li>
+    </ul>
+
+    <button class="restart-btn">다시 시작하기</button>
+  </main>
+</template>
+
+<style scoped>
+.ranking-container {
+  @apply flex flex-col items-center px-4 py-12 bg-gray-100 font-sans;
+}
+
+.ranking-title {
+  @apply text-[22px] font-bold text-gray-600 mb-6;
+}
+
+.score-box {
+  @apply bg-white rounded-xl shadow px-6 py-5 max-w-[340px] w-full text-center mb-6;
+}
+
+.my-score {
+  @apply text-[14px] text-gray-600 mb-2;
+}
+
+.percent-rank {
+  @apply text-[18px] font-bold text-gray-600 mb-3;
+}
+
+.percent-rank strong {
+  @apply text-yellow-400;
+}
+
+.share-section {
+  @apply flex justify-center gap-3 mt-3;
+}
+
+.sns-btn {
+  @apply w-9 h-9 rounded-full text-white font-bold flex items-center justify-center cursor-pointer transition;
+}
+
+.twitter {
+  @apply bg-blue-400 hover:bg-blue-500;
+}
+
+.facebook {
+  @apply bg-blue-700 hover:bg-blue-800;
+}
+
+.link {
+  @apply bg-gray-500 hover:bg-gray-600;
+}
+
+.rank-list {
+  @apply flex flex-col gap-3 w-full max-w-[340px] mb-8;
+}
+
+.rank-card {
+  @apply flex justify-between items-center bg-white px-5 py-3 rounded-md shadow text-[14px] text-gray-700;
+}
+
+.rank-1 {
+  @apply border-2 border-yellow-400;
+}
+
+.rank-2 {
+  @apply bg-yellow-50;
+}
+
+.rank-3 {
+  @apply bg-gray-100;
+}
+
+.my-rank {
+  @apply bg-pink-50 border-2 border-pink-400;
+}
+
+.rank-text {
+  @apply font-semibold flex items-center gap-1;
+}
+
+.score-text {
+  @apply text-gray-500;
+}
+
+.restart-btn {
+  @apply mt-2 px-5 py-2 text-[14px] bg-pink-500 text-white font-semibold rounded-md hover:bg-pink-600 transition;
+}
+</style>

--- a/src/features/game/views/GameStart.vue
+++ b/src/features/game/views/GameStart.vue
@@ -1,0 +1,59 @@
+<script setup>
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import ImageSelectModal from '@/features/game/components/ImageSelectModal.vue';
+import { useGameStore } from '@/stores/useGameStore.js';
+
+const showModal = ref(false);
+const gameStore = useGameStore();
+const router = useRouter();
+
+function handleOpenModal() {
+  showModal.value = true;
+}
+
+function handleImagesSelected(files) {
+  const fileList = [...files].slice(0, 8); // 최대 8장 제한
+  gameStore.setSelectedFiles(fileList); // File 객체 그대로 저장
+  showModal.value = false;
+  router.push('/game/play');
+}
+</script>
+
+<template>
+  <main class="game-start-wrapper">
+    <section class="start-container">
+      <h1 class="title">🎮 Catch Me 카드 게임</h1>
+      <p class="description">카드를 뒤집어 같은 고양이를 찾아보세요!</p>
+      <button class="start-button" @click="handleOpenModal">카드 이미지 선택하기</button>
+    </section>
+
+    <ImageSelectModal
+      v-if="showModal"
+      @close="showModal = false"
+      @imagesSelected="handleImagesSelected"
+    />
+  </main>
+</template>
+
+<style scoped>
+.game-start-wrapper {
+  @apply flex items-center justify-center min-h-screen bg-gray-50;
+}
+
+.start-container {
+  @apply bg-white border border-pink-300 p-10 rounded-lg text-center shadow-lg max-w-md;
+}
+
+.title {
+  @apply text-2xl text-pink-500 font-bold mb-4;
+}
+
+.description {
+  @apply text-gray-600 mb-6;
+}
+
+.start-button {
+  @apply px-6 py-3 text-base bg-pink-500 text-white rounded-md cursor-pointer hover:bg-pink-600;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import { useAuthStore } from '@/stores/auth.js';
 import SidebarMainLayout from '@/components/layout/SidebarMainLayout.vue';
 import AppShell from '@/components/AppShell.vue';
 import { JjureRoutes } from '@/features/jjure/router.js';
+import gameRoutes from '@/features/game/router.js';
 
 const router = createRouter({
   history: createWebHistory(),
@@ -10,7 +11,7 @@ const router = createRouter({
     {
       path: '/',
       component: AppShell,
-      children: [...JjureRoutes],
+      children: [...JjureRoutes, ...gameRoutes],
     },
   ],
 });

--- a/src/stores/useGameStore.js
+++ b/src/stores/useGameStore.js
@@ -1,0 +1,41 @@
+// useGameStore.js
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useGameStore = defineStore('game', () => {
+  const selectedFiles = ref([]);
+  const imageUrls = ref([]);
+  const resultTime = ref(null); // 걸린 시간 (초)
+  const gameStatus = ref(null); // 'success' | 'fail'
+
+  function setSelectedFiles(files) {
+    selectedFiles.value = files;
+  }
+
+  function setImageUrls(urls) {
+    imageUrls.value = urls;
+  }
+
+  function setResult({ time, status }) {
+    resultTime.value = time;
+    gameStatus.value = status; // 'success' 또는 'fail'
+  }
+
+  function resetGame() {
+    selectedFiles.value = [];
+    imageUrls.value = [];
+    resultTime.value = null;
+    gameStatus.value = null;
+  }
+
+  return {
+    selectedFiles,
+    imageUrls,
+    resultTime,
+    gameStatus,
+    setSelectedFiles,
+    setImageUrls,
+    setResult,
+    resetGame,
+  };
+});

--- a/src/utills/toast.js
+++ b/src/utills/toast.js
@@ -1,5 +1,4 @@
 import { useToast } from 'vue-toastification';
-개;
 
 const toast = useToast();
 


### PR DESCRIPTION
## [FE] Catch Me! 고양이 카드 게임 기능 구현 PR

### 🔧 주요 구현 내역

이번 PR에서는 게임 시작 → 게임 진행 → 랭킹 조회 → 점수 공유까지의 전체 플레이 흐름에 대한 프론트엔드 기능을 구성하였습니다.

---

### 1. 게임 시작 페이지 (`/game/start`)

- 게임 소개 및 시작 버튼 UI 구현
- 카드 게임 시작 시 `/game/play`로 라우팅 처리
- Pinia의 `gameStore`를 통해 게임 상태(`status`, `time`) 초기화

---

### 2. 게임 진행 페이지 (`/game/play`)

- 카드 클릭 로직 (`handleCardClick`) 구현
  - 동일 카드 클릭 방지
  - 두 장 뒤집은 뒤 매칭 여부 판단
  - 매칭 실패 시 자동 리셋 타이머 처리
- 타이머 기능 (밀리초 단위 `elapsedMs`) 구현
  - `requestAnimationFrame` 기반 부드러운 진행
- 성공 시:
  - 모든 카드 매칭 성공 → 게임 종료 처리
  - `gameStore.setResult({ time, status: 'success' })` 저장
  - `/games/scores` API로 점수 저장 요청
  - `/game/ranking`으로 이동
- 실패 시:
  - 120초 초과 → `gameStore.setResult({ status: 'fail' })`
  - 랭킹 조회 시 실패 메시지 출력

---

### 3. 랭킹 조회 페이지 (`/game/ranking`)

- Pinia 상태 기반 접근 제어:
  - `gameStore.status === null` → `/game/start` 리다이렉션
- `status === 'fail'`일 경우:
  - `"맞추기 실패ㅠㅠ"`, `"아쉽다냥..."` 출력
  - 서버에서 top 10 랭커만 조회
- `status === 'success'`일 경우:
  - `gameStore.time`을 기준으로 내 기록 출력
  - 내 순위에 따라 "상위 {{xx}}%" 출력
  - 전체 상위 랭커 리스트 출력
  - 내 순위 강조 (배경색, 테두리, `(나)` 텍스트)
- 왕관 아이콘(`Font Awesome`)으로 1위 표시
- 각 순위별 스타일 적용 (1위 border, 2위/3위 배경 강조)

---

### 4. 점수 공유 기능

- SNS 공유 버튼 구성
  - 트위터 공유: `intent/tweet` 링크로 내 기록 + 현재 페이지 공유
  - 페이스북 공유: `sharer.php` 사용
  - 링크 복사: `navigator.clipboard.writeText()` 사용 후 `alert`
- 공유 문구: `내가 Catch Me! 게임에서 {{xx}}초 기록! 너도 도전해봐!`

---

### 💡 추후 계획

OG 이미지 기반 고급 공유 기능도 고려 중이며, 아래 방식으로 확장 예정입니다:

#### ✅ OG 이미지 공유를 위한 구조 설계 예정

- 카드판 완성 시점에 `html2canvas`를 사용해 사용자 플레이 화면을 이미지로 캡처
- 해당 이미지를 Presigned URL 기반으로 S3에 업로드
- `/share/:id`와 같은 고유 공유 URL을 구성
- 해당 경로는 SSG 기반 HTML로 구성되어 `<head>`에 `og:image`, `og:title` 등을 포함
- SNS(특히 트위터, 페이스북, 카카오톡) 공유 시 자동 썸네일 이미지 노출 가능

#### ✅ 카카오톡 공유 연동 고려

- 카카오 JavaScript SDK를 활용한 `Kakao.Share.sendDefault()` 연동 예정
- 앱 키 및 이미지 CDN 연동 필요
- OG 이미지 공유와 병행하여 진행 예정

---