### PR TITLE
[FE] CAT-207 피드 좋아요 api 연동

### DIFF
--- a/src/api/like.js
+++ b/src/api/like.js
@@ -1,0 +1,16 @@
+import api from './axios.js';
+
+export const likeFeed = (data) =>
+  api.post('/likes', data, {
+    headers: {
+      'X-USER-ID': 1,
+    },
+  });
+
+export const unLikeFeed = (data) =>
+  api.delete('/likes', {
+    data,
+    headers: {
+      'X-USER-ID': 1,
+    },
+  });

--- a/src/composable/usePagination.js
+++ b/src/composable/usePagination.js
@@ -4,7 +4,7 @@ import { ref } from 'vue';
 export function usePagination(fetchFn) {
   const items = ref([]);
   const page = ref(0);
-  const size = ref(2);
+  const size = ref(3);
   const hasNext = ref(true);
   const isLoading = ref(false);
 

--- a/src/features/feed/components/FeedActions.vue
+++ b/src/features/feed/components/FeedActions.vue
@@ -25,30 +25,41 @@
 
 <script setup>
 import { ref } from 'vue';
+import { likeFeed, unLikeFeed } from '@/api/like.js';
 
 const props = defineProps({
   likeCount: Number,
   commentCount: Number,
   liked: Boolean,
+  feedId: Number,
 });
 
 const liked = ref(props.liked);
 const likeCount = ref(props.likeCount);
 const animateLike = ref(false);
-const toggleLike = () => {
-  if (liked.value) {
-    likeCount.value -= 1;
-  } else {
-    likeCount.value += 1;
+const toggleLike = async () => {
+  const payload = {
+    targetId: props.feedId, // ← 부모 컴포넌트에서 넘겨줘야 함
+    targetType: 'FEED',
+  };
+
+  try {
+    if (liked.value) {
+      await unLikeFeed(payload);
+      likeCount.value -= 1;
+    } else {
+      await likeFeed(payload);
+      likeCount.value += 1;
+    }
+    liked.value = !liked.value;
+
+    animateLike.value = true;
+    setTimeout(() => {
+      animateLike.value = false;
+    }, 200);
+  } catch (e) {
+    console.error('좋아요 처리 실패:', e);
   }
-  liked.value = !liked.value;
-
-  animateLike.value = true;
-  setTimeout(() => {
-    animateLike.value = false;
-  }, 200);
-
-  //API 호출
 };
 </script>
 

--- a/src/features/feed/components/FeedCard.vue
+++ b/src/features/feed/components/FeedCard.vue
@@ -15,6 +15,7 @@ defineProps({ feed: Object });
       :likeCount="feed.likeCount"
       :commentCount="feed.commentCount"
       :liked="feed.liked"
+      :feedId="feed.id"
     />
     <div class="content-wrapper">
       <span class="author">{{ feed.author.nickname }}</span>

--- a/src/features/feed/views/FeedDetailPage.vue
+++ b/src/features/feed/views/FeedDetailPage.vue
@@ -50,6 +50,7 @@ import { fetchFeed } from '@/api/feed.js';
 import FeedCarousel from '../components/FeedCarousel.vue';
 import FeedHeader from '../components/FeedHeader.vue';
 import { startLoading } from '@/composable/useLoadingBar.js';
+import { likeFeed, unLikeFeed } from '@/api/like.js';
 
 const feed = ref(null);
 const route = useRoute();
@@ -69,22 +70,30 @@ const close = () => {
 };
 
 const animateLike = ref(false);
-const toggleLike = () => {
-  if (liked.value) {
-    likeCount.value -= 1;
-  } else {
-    likeCount.value += 1;
+const toggleLike = async () => {
+  const payload = {
+    targetId: route.params.id, // ← 부모 컴포넌트에서 넘겨줘야 함
+    targetType: 'FEED',
+  };
+
+  try {
+    if (liked.value) {
+      await unLikeFeed(payload);
+      likeCount.value -= 1;
+    } else {
+      await likeFeed(payload);
+      likeCount.value += 1;
+    }
+    liked.value = !liked.value;
+
+    animateLike.value = true;
+    setTimeout(() => {
+      animateLike.value = false;
+    }, 200);
+  } catch (e) {
+    console.error('좋아요 처리 실패:', e);
   }
-  liked.value = !liked.value;
-
-  animateLike.value = true;
-  setTimeout(() => {
-    animateLike.value = false;
-  }, 200);
-
-  //API 호출
 };
-
 onMounted(async () => {
   const feedId = route.params.id;
   startLoading();


### PR DESCRIPTION
### 🛰️ Issue
- 피드 좋아요 버튼에 좋아요, 좋아요 취소 api 연동

### 🪐 작업 내용
- 피드 목록 페이지 좋아요 버튼에 좋아요, 좋아요 취소 api 연동
- 피드 상세 조회 페이지 좋아요 버튼에 좋아요, 좋아요 취소 api 연동
