### PR TITLE
fix: 리프레시 토큰 인증 복구

### DIFF
--- a/src/features/member/views/SignupExtraView.vue
+++ b/src/features/member/views/SignupExtraView.vue
@@ -55,22 +55,31 @@ onMounted(async () => {
     return;
   }
 
-  try {
-    const res = await getTempMemberInfo(email, social.toUpperCase());
-    const data = res.data.data;
+  const submitSignup = async () => {
+    startLoading();
+    try {
+      const formData = new FormData();
+      formData.append('name', name.value);
+      formData.append('contactNumber', contactNumber.value.replace(/-/g, ''));
+      formData.append('nickname', nickname.value);
+      formData.append('email', email);
+      formData.append('social', social.toUpperCase());
 
-    if (data.name) {
-      name.value = data.name;
-      nameReadonly.value = true;
+      if (profileImage.value) {
+        formData.append('profileImage', profileImage.value);
+      }
+
+      const { data } = await socialSignupExtra(formData);
+
+      showSuccessToast('Catchy에 오신 것을 환영합니다!');
+      router.push('/feed');
+    } catch (error) {
+      const { errorCode, message } = error.response?.data ?? {};
+      showErrorToast(`${message ?? '알 수 없는 오류가 발생했습니다.'}`);
+    } finally {
+      stopLoading(); // 항상 실행됨
     }
-    if (data.contactNumber) {
-      contactNumber.value = data.contactNumber;
-      contactReadonly.value = true;
-    }
-  } catch (err) {
-    showErrorToast('회원 정보를 불러오지 못했습니다. 다시 시도해주세요.');
-    router.push('/member/start');
-  }
+  };
 });
 
 // 회원가입 제출
@@ -79,7 +88,7 @@ const submitSignup = async () => {
     startLoading();
     const formData = new FormData();
     formData.append('name', name.value);
-    formData.append('contactNumber', contactNumber.value.replace(/-/g, ''));
+    formData.append('contactNumber', contactNumber.value);
     formData.append('nickname', nickname.value);
     formData.append('email', email);
     formData.append('social', social.toUpperCase());
@@ -91,7 +100,6 @@ const submitSignup = async () => {
     const { data } = await socialSignupExtra(formData);
 
     showSuccessToast('Catchy에 오신 것을 환영합니다!');
-    defaultProfileStore.clearProfileImage();
     router.push('/feed');
     stopLoading();
   } catch (error) {


### PR DESCRIPTION
##✅ 전 코드 (문제 있음)
사용자가 로그인하면 accessToken이 Pinia에 저장됨
sessionStorage에 저장되어 새로고침 후 복구 가능하지만,
accessToken이 만료되거나 사라지면 재발급을 시도하지 않음
즉, refreshToken을 활용하지 않고 있었음
새로고침 후 인증 상태가 풀리게 됨 → 로그아웃처럼 보임

##✅ 현재 코드 (문제 해결됨)
새로고침 후 앱이 시작될 때:
reissueAccessToken() → 서버에 refreshToken을 쿠키로 전송
서버가 accessToken을 새로 발급해서 응답
프론트는 받은 accessToken을 authStore.setAuth()로 저장
따라서 accessToken이 사라졌어도 refreshToken이 유효하면 자동 복구됨

